### PR TITLE
Add Google Analytics 4 support

### DIFF
--- a/lib/event_tracker/integration/google_analytics.rb
+++ b/lib/event_tracker/integration/google_analytics.rb
@@ -1,17 +1,19 @@
 class EventTracker::Integration::GoogleAnalytics < EventTracker::Integration::Base
   def init
     <<-EOD
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtag/js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer', '#{@key}');
 
-      ga('create', '#{@key}', 'auto', {'name': 'event_tracker'});
-      ga('event_tracker.send', 'pageview');
+      gtag('js', new Date());
+      gtag('config', '#{@key}');
     EOD
   end
 
   def track(event_name, properties = {})
-    %Q{ga('event_tracker.send', 'event', 'event_tracker', '#{event_name}');}
+    properties_js = properties.to_json
+    %Q{gtag('event', '#{event_name}', #{properties_js});}
   end
 end


### PR DESCRIPTION
This is based on https://github.com/doorkeeper/event_tracker/pull/19. The PR has been open for over a year, with no perceived movement, so instead we'll update our fork of event_tracker to the latest and include this PR's contents.